### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-kv-unix.opam
+++ b/mirage-kv-unix.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ocaml" {>= "4.05.0"}
   "cstruct" {>= "3.2.0"}
   "mirage-kv-lwt" {>= "1.0.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.