### PR TITLE
Address reviews from @reynir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## v3.0.1 (2024-04-17)
+
+* Adress reviews from @reynir (#7, @samoht and @reynir)
+  - Fail when keys contain '.' and '..' to match other `mirage-kv-*`
+    implementations
+  - Use failwith instead of Lwt.failwith
+  - Use Lwt.reraise instead of Lwt.fail
+  - `digest` on directories now return an error
+  - `set_partial` on directories return an error while `set` on directories work
+    (and remove the directory)
+  - fix fd leak in `set` and `set_partial`
+
 ## v3.0.0 (2024-04-16)
 
 * Update to mirage-kv>6 (#5, @samoht)

--- a/mirage-kv-unix.opam
+++ b/mirage-kv-unix.opam
@@ -17,9 +17,9 @@ build: [
 depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.08.0"}
-  "mirage-kv" {>= "6.0.0"}
+  "mirage-kv" {>= "6.1.1"}
   "optint"
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.7.0"}
   "ptime"
   "cstruct" {with-test & >= "3.2.0"}
   "rresult" {with-test}

--- a/test/test_kv_unix.ml
+++ b/test/test_kv_unix.ml
@@ -201,12 +201,7 @@ let write_overwrite_dir () =
   let subdir = Mirage_kv.Key.(dirname / "data") in
   let* () = set kv subdir "noooooo" in
   let+ w = KV.set kv dirname "noooooo" in
-  match w with
-  | Error (`Key_exists _) -> ()
-  | Error e -> assert_write_fail e
-  | Ok () ->
-      Alcotest.failf
-        "write overwrote an entire directory! That should not happen!"
+  match w with Ok () -> () | Error e -> assert_write_fail e
 
 let write_big_file () =
   let how_big = 4100 in


### PR DESCRIPTION
- Fail when keys contain '.' and '..' to match other `mirage-kv-*` implementations
- Use failwith instead of Lwt.failwith
- Use Lwt.reraise instead of Lwt.fail
- `digest` on directories now return an error
- `set_partial` on directories return an error while `set` on directories work (and remove the directory)
- fix fd leak in `set` and `set_partial`